### PR TITLE
Npo

### DIFF
--- a/examples/npo.py
+++ b/examples/npo.py
@@ -11,14 +11,9 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
 
     store = KnowledgeStore(npo=True)
-    #print_knowledge(store, 'ilxtr:neuron-type-keast-8')
-    # print_knowledge(store, 'ilxtr:sparc-nlp/mmset1/3a')
-    # print_knowledge(store, 'ilxtr:sparc-nlp/mmset1/4')
-    # print_knowledge(store, 'ilxtr:sparc-nlp/mmset2cn/6')
-
-    # print_knowledge(store, 'ilxtr:neuron-type-keast-10')
-    print_knowledge(store, 'ilxtr:NeuronAacar')
-
-    pprint(store.connectivity_models())
-
+    print_knowledge(store, 'ilxtr:NeuronKblad')
+    print_knowledge(store, 'ilxtr:neuron-type-keast-8')
+    print_knowledge(store, 'ilxtr:sparc-nlp/mmset1/3a')
+    print_knowledge(store, 'ilxtr:sparc-nlp/mmset1/4')
+    print_knowledge(store, 'ilxtr:sparc-nlp/mmset2cn/6')
     store.close()

--- a/examples/npo.py
+++ b/examples/npo.py
@@ -12,7 +12,13 @@ if __name__ == '__main__':
 
     store = KnowledgeStore(npo=True)
     #print_knowledge(store, 'ilxtr:neuron-type-keast-8')
-    print_knowledge(store, 'ilxtr:sparc-nlp/mmset1/3a')
-    print_knowledge(store, 'ilxtr:sparc-nlp/mmset1/4')
-    print_knowledge(store, 'ilxtr:sparc-nlp/mmset2cn/6')
+    # print_knowledge(store, 'ilxtr:sparc-nlp/mmset1/3a')
+    # print_knowledge(store, 'ilxtr:sparc-nlp/mmset1/4')
+    # print_knowledge(store, 'ilxtr:sparc-nlp/mmset2cn/6')
+
+    # print_knowledge(store, 'ilxtr:neuron-type-keast-10')
+    print_knowledge(store, 'ilxtr:NeuronAacar')
+
+    pprint(store.connectivity_models())
+
     store.close()

--- a/mapknowledge/__init__.py
+++ b/mapknowledge/__init__.py
@@ -200,30 +200,30 @@ class KnowledgeStore(KnowledgeBase):
 
     def connectivity_models(self):
     #=============================
-            def cached_models():
-                return {row[0]: {'label': row[1], 'version': row[2]}
-                    for row in self.db.execute('''
-                        select c.model, l.label, c.version from connectivity_models as c
-                            left join labels as l on c.model = l.entity order by model
-                        ''')} if self.db is not None else {}
+        def cached_models():
+            return {row[0]: {'label': row[1], 'version': row[2]}
+                for row in self.db.execute('''
+                    select c.model, l.label, c.version from connectivity_models as c
+                        left join labels as l on c.model = l.entity order by model
+                    ''')} if self.db is not None else {}
 
-            if self.__scicrunch is not None:
-                sckan_models = self.__scicrunch.connectivity_models()
-                if not self.__cleaned_connectivity:
-                    model_info = cached_models()
-                    for model, properties in sckan_models.items():
-                        if ((cached_properties := model_info.get(model)) is not None
-                        and cached_properties['version'] != properties['version']):
-                            raise ValueError(f'Connectivity model {model} has changed in SCKAN -- please `clean connectivity`')
-                if self.db is not None and not self.read_only:
-                    if not self.db.in_transaction:
-                        self.db.execute('begin')
-                    for model, properties in sckan_models.items():
-                        self.db.execute('replace into connectivity_models values (?, ?)', (model, properties['version']))
-                        self.db.execute('replace into labels values (?, ?)', (model, properties['label']))
-                    self.db.commit()
-                return sckan_models
-            return cached_models()
+        if self.__scicrunch is not None:
+            sckan_models = self.__scicrunch.connectivity_models()
+            if not self.__cleaned_connectivity:
+                model_info = cached_models()
+                for model, properties in sckan_models.items():
+                    if ((cached_properties := model_info.get(model)) is not None
+                    and cached_properties['version'] != properties['version']):
+                        raise ValueError(f'Connectivity model {model} has changed in SCKAN -- please `clean connectivity`')
+            if self.db is not None and not self.read_only:
+                if not self.db.in_transaction:
+                    self.db.execute('begin')
+                for model, properties in sckan_models.items():
+                    self.db.execute('replace into connectivity_models values (?, ?)', (model, properties['version']))
+                    self.db.execute('replace into labels values (?, ?)', (model, properties['label']))
+                self.db.commit()
+            return sckan_models
+        return cached_models()
 
     def labels(self):
     #================

--- a/mapknowledge/__init__.py
+++ b/mapknowledge/__init__.py
@@ -175,7 +175,7 @@ class KnowledgeStore(KnowledgeBase):
             scicrunch_msg = f"using {release} SCKAN{built} from {self.__scicrunch.sparc_api_endpoint}"
             if self.__npo_db is not None:
                 npo_built = f" built at {self.__npo_db.sckan_build()['release']}"
-                scicrunch_msg = f"{scicrunch_msg } and NPO {npo_built}"
+                scicrunch_msg = f"{scicrunch_msg } and NPO{npo_built}"
         else:
             self.__scicrunch = None
             scicrunch_msg = 'not using SCKAN'

--- a/mapknowledge/__init__.py
+++ b/mapknowledge/__init__.py
@@ -197,30 +197,32 @@ class KnowledgeStore(KnowledgeBase):
 
     def connectivity_models(self):
     #=============================
-        def cached_models():
-            return {row[0]: {'label': row[1], 'version': row[2]}
-                for row in self.db.execute('''
-                    select c.model, l.label, c.version from connectivity_models as c
-                        left join labels as l on c.model = l.entity order by model
-                    ''')} if self.db is not None else {}
+            def cached_models():
+                return {row[0]: {'label': row[1], 'version': row[2]}
+                    for row in self.db.execute('''
+                        select c.model, l.label, c.version from connectivity_models as c
+                            left join labels as l on c.model = l.entity order by model
+                        ''')} if self.db is not None else {}
 
-        if self.__scicrunch is not None:
-            sckan_models = self.__scicrunch.connectivity_models()
-            if not self.__cleaned_connectivity:
-                model_info = cached_models()
-                for model, properties in sckan_models.items():
-                    if ((cached_properties := model_info.get(model)) is not None
-                     and cached_properties['version'] != properties['version']):
-                        raise ValueError(f'Connectivity model {model} has changed in SCKAN -- please `clean connectivity`')
-            if self.db is not None and not self.read_only:
-                if not self.db.in_transaction:
-                    self.db.execute('begin')
-                for model, properties in sckan_models.items():
-                    self.db.execute('replace into connectivity_models values (?, ?)', (model, properties['version']))
-                    self.db.execute('replace into labels values (?, ?)', (model, properties['label']))
-                self.db.commit()
-            return sckan_models
-        return cached_models()
+            if self.__npo_db is not None:
+                return self.__npo_db.connectivity_models()
+            elif self.__scicrunch is not None:
+                sckan_models = self.__scicrunch.connectivity_models()
+                if not self.__cleaned_connectivity:
+                    model_info = cached_models()
+                    for model, properties in sckan_models.items():
+                        if ((cached_properties := model_info.get(model)) is not None
+                        and cached_properties['version'] != properties['version']):
+                            raise ValueError(f'Connectivity model {model} has changed in SCKAN -- please `clean connectivity`')
+                if self.db is not None and not self.read_only:
+                    if not self.db.in_transaction:
+                        self.db.execute('begin')
+                    for model, properties in sckan_models.items():
+                        self.db.execute('replace into connectivity_models values (?, ?)', (model, properties['version']))
+                        self.db.execute('replace into labels values (?, ?)', (model, properties['label']))
+                    self.db.commit()
+                return sckan_models
+            return cached_models()
 
     def labels(self):
     #================

--- a/mapknowledge/__init__.py
+++ b/mapknowledge/__init__.py
@@ -175,6 +175,10 @@ class KnowledgeStore(KnowledgeBase):
         else:
             self.__scicrunch = None
             scicrunch_msg = 'not using SCKAN'
+        self.__npo_db = NpoSparql() if npo else None
+        if self.__npo_db:
+            built = f" built at {self.__npo_db.npo_released()}"
+            scicrunch_msg = f"using NPO{built}"
         log.info(f'Map Knowledge version {__version__} {cache_msg} {scicrunch_msg}')
         # Optionally clear local connectivity knowledge
         if (self.db is not None and clean_connectivity):
@@ -189,7 +193,6 @@ class KnowledgeStore(KnowledgeBase):
             self.db.execute(f'delete from connectivity_models')
             self.db.execute('commit')
         self.__cleaned_connectivity = clean_connectivity
-        self.__npo_db = NpoSparql() if npo else None
 
     @property
     def scicrunch(self):

--- a/mapknowledge/__init__.py
+++ b/mapknowledge/__init__.py
@@ -163,7 +163,11 @@ class KnowledgeStore(KnowledgeBase):
             cache_msg = f'with cache {db_name}'
         else:
             cache_msg = f'with no cache'
-        if scicrunch_api is not None:
+        if npo:
+            self.__scicrunch = NpoSparql()
+            built = f" built at {self.__scicrunch.sckan_build()['release']}"
+            scicrunch_msg = f"using NPO{built}"
+        elif scicrunch_api is not None:
             self.__scicrunch = SciCrunch(api_endpoint=scicrunch_api,
                                          scicrunch_release=scicrunch_release,
                                          scicrunch_key=scicrunch_key)
@@ -175,10 +179,6 @@ class KnowledgeStore(KnowledgeBase):
         else:
             self.__scicrunch = None
             scicrunch_msg = 'not using SCKAN'
-        self.__npo_db = NpoSparql() if npo else None
-        if self.__npo_db:
-            built = f" built at {self.__npo_db.npo_released()}"
-            scicrunch_msg = f"using NPO{built}"
         log.info(f'Map Knowledge version {__version__} {cache_msg} {scicrunch_msg}')
         # Optionally clear local connectivity knowledge
         if (self.db is not None and clean_connectivity):
@@ -207,9 +207,7 @@ class KnowledgeStore(KnowledgeBase):
                             left join labels as l on c.model = l.entity order by model
                         ''')} if self.db is not None else {}
 
-            if self.__npo_db is not None:
-                return self.__npo_db.connectivity_models()
-            elif self.__scicrunch is not None:
+            if self.__scicrunch is not None:
                 sckan_models = self.__scicrunch.connectivity_models()
                 if not self.__cleaned_connectivity:
                     model_info = cached_models()
@@ -259,13 +257,10 @@ class KnowledgeStore(KnowledgeBase):
 
         if len(knowledge) == 0 or entity == knowledge.get('label', entity):
 
-            if self.__npo_db is not None: ### and entity.startswith(NPO_NLP_NEURONS):
-                knowledge = self.__npo_db.get_knowledge(entity)
-
-            elif self.__scicrunch is not None:
+            if self.__scicrunch is not None:
                 # Consult SciCrunch if we don't know about the entity
                 knowledge = self.__scicrunch.get_knowledge(entity)
-                if 'connectivity' in knowledge:
+                if 'connectivity' in knowledge and isinstance(self.__scicrunch, SciCrunch):
                     # Get phenotype, taxon, and other metadata
                     knowledge.update(self.__scicrunch.connectivity_metadata(entity))
 

--- a/mapknowledge/nposparql.py
+++ b/mapknowledge/nposparql.py
@@ -30,6 +30,7 @@ import ast
 #===============================================================================
 
 from .namespaces import NAMESPACES
+from .apinatomy import EXCLUDED_LAYERS
 
 #===============================================================================
 
@@ -48,19 +49,6 @@ NPO_DIR = "ttl/generated/neurons"
 NPO_SOURCE = f"https://raw.githubusercontent.com/{NPO_OWNER}/{NPO_REPO}/{NPO_BRANCH}/"
 NPO_PARTIAL_ORDER = "apinat-partial-orders.ttl"
 NPO_PARTIAL_ORDER_URL = f'{NPO_SOURCE}{NPO_DIR}/{NPO_PARTIAL_ORDER}'
-
-EXCLUDED_LAYERS = (
-    None,
-    'UBERON:0000010',      # peripheral nervous system
-    'UBERON:0000178',      # blood
-    'UBERON:0000468',      # multicellular organism
-    'UBERON:0001017',      # central nervous system
-    'UBERON:0001359',      # cerebrospinal fluid
-    'UBERON:0002318',      # spinal cord white matter
-    'UBERON:0003714',      # neural tissue
-    'UBERON:0005844',      # spinal cord segment
-    'UBERON:0016549',      # cns white matter
-)
 
 #===============================================================================
 
@@ -279,7 +267,6 @@ DB_VERSION = """
     PREFIX TTL: <https://raw.githubusercontent.com/SciCrunch/NIF-Ontology/neurons/ttl/>
     SELECT DISTINCT ?NPO ?SimpleSCKAN WHERE{{
         OPTIONAL{{TTL:npo.ttl owl:versionInfo ?NPO.}}
-        OPTIONAL{{TTL:simple-sckan.ttl owl:versionInfo ?SimpleSCKAN.}}
     }}
 """
 
@@ -483,7 +470,12 @@ class NpoSparql:
             models[rst['Model_ID']] = {"label": "", "version": ""}
         return models
 
-    def npo_released(self):
-        return self.__db_version()['NPO']
+    def sckan_build(self):
+        return {
+            'created': self.__db_version()['NPO'],
+            'released': self.__db_version()['NPO'],
+            'release': self.__db_version()['NPO'],
+            'history': self.__db_version()['NPO'],
+        }
 
 #===============================================================================


### PR DESCRIPTION
In this pull request:
- mapknowledge is able draw neurons from NPO only:
    - Get partial orders of Apinatomy neurons from ttl (this should be remove after NPO fix neuron connectivity of Apinatomy Model)
- Modify nposparql.py:
    - add DB_VERSION sparql, __db_version & npo_released() methods —> to get NPO released
- Modify METADATA sparql:
    - Can handle incomplete neuron metadata missing soma and axon terminal
    - Identify neuron entity only from Apinatomy & NLP
    - Return more than one phenotypes.
    - Return NPO released
- Modify KnowledgeStore to show NPO as info