### PR TITLE
make sure to retrieve neuron connectivity from NPO

### DIFF
--- a/mapknowledge/nposparql.py
+++ b/mapknowledge/nposparql.py
@@ -292,6 +292,7 @@ class NpoSparql:
     def __init__(self):
         self.__sparql = SPARQLWrapper2(NPO_SPARQL_ENDPOINT)
         self.__load_apinatomy_connectivities() # load from file due to incompleteness in NPO
+        self.__load_connectivities() # get all connectivities promptly
 
     def query(self, sparql) -> list[dict]:
         self.__sparql.setQuery(sparql)
@@ -482,11 +483,15 @@ class NpoSparql:
                             filtered_connectivities += [edge]
                 self.__apinat_connectivities[neuron.strip()] = filtered_connectivities
 
-    def connectivity_models(self):
+    def __load_connectivities(self):
         models = {}
         for rst in self.__connectivity_models():
-            models[rst['Model_ID']] = {"label": "", "version": ""}
-        return models
+            for neuron in self.__model_knowledge(rst['Model_ID']):
+                models[neuron['Neuron_ID']] = {"label": "", "version": ""}
+        self.__connectivities = models
+
+    def connectivity_models(self):
+        return self.__connectivities
 
     def build(self):
         return {


### PR DESCRIPTION
Mapknowledge 0.16.1 cannot retrive neuron type knowledge from NPO.  The current call to `example/npo.py` returns:

```
    ...
    ilxtr:sparc-nlp/mmset1/3a:
    WARNING:root:Couldn't access https://scicrunch.org/api/1/sckan-scigraph/dynamic/demos/apinat/neru-7/ilxtr:sparc-nlp/mmset1/3a.json: Not Found
    WARNING:root:Unknown anatomical entity: ilxtr:sparc-nlp/mmset1/3a
    {'label': 'ilxtr:sparc-nlp/mmset1/3a'}
    ...
```
This is due to, `connectivity_models()` in `NpoSparql` just returns a list of models such as `ilxtr:NeuronAacar` and `ilxtr:NeuronKblad`.

Therefore 
```
    npo_models = self.__npo_db.connectivity_models()
    self.__npo_entities = list(npo_models.keys())
```
at https://github.com/AnatomicMaps/map-knowledge/blob/be8ab3ae4cf315414d08bdb8214674e38ca05c3f/mapknowledge/__init__.py#L236C16-L236C17) is not loading all available neuron connectivities in NPO.

In this pull request, `connectivity_models()` in `NpoSparql` is modified.