### PR TITLE
Reverting modification to connectivity_models() and then adding connectivity_paths()

### DIFF
--- a/mapknowledge/__init__.py
+++ b/mapknowledge/__init__.py
@@ -191,6 +191,7 @@ class KnowledgeStore(KnowledgeBase):
             self.__npo_db = NpoSparql()
             npo_build = f" built at {self.__npo_db.build()['released']}" if log_build else ''
             log.info(f'With NPO{npo_build}')
+            self.__npo_entities = list(self.__npo_db.connectivity_paths().keys())
         else:
             self.__npo_db = None
             log.info('Without NPO')
@@ -233,7 +234,6 @@ class KnowledgeStore(KnowledgeBase):
                 # Future: need to warn when NPO has been updated and make sure user
                 #         clears the cache...
                 npo_models = self.__npo_db.connectivity_models()
-                self.__npo_entities = list(npo_models.keys())
                 return npo_models
             else:
                 log.warning('NPO connectivity models requested but no connection to NPO service')

--- a/mapknowledge/__init__.py
+++ b/mapknowledge/__init__.py
@@ -234,6 +234,7 @@ class KnowledgeStore(KnowledgeBase):
                 # Future: need to warn when NPO has been updated and make sure user
                 #         clears the cache...
                 npo_models = self.__npo_db.connectivity_models()
+                self.__npo_entities += list(npo_models.keys())
                 return npo_models
             else:
                 log.warning('NPO connectivity models requested but no connection to NPO service')

--- a/mapknowledge/nposparql.py
+++ b/mapknowledge/nposparql.py
@@ -292,6 +292,7 @@ class NpoSparql:
     def __init__(self):
         self.__sparql = SPARQLWrapper2(NPO_SPARQL_ENDPOINT)
         self.__load_apinatomy_connectivities() # load from file due to incompleteness in NPO
+        self.__load_connectivity_paths() # get all connectivity paths promptly
 
     def query(self, sparql) -> list[dict]:
         self.__sparql.setQuery(sparql)
@@ -482,11 +483,21 @@ class NpoSparql:
                             filtered_connectivities += [edge]
                 self.__apinat_connectivities[neuron.strip()] = filtered_connectivities
 
+    def __load_connectivity_paths(self):
+         models = {}
+         for rst in self.__connectivity_models():
+             for neuron in self.__model_knowledge(rst['Model_ID']):
+                 models[neuron['Neuron_ID']] = {"label": "", "version": ""}
+         self.__connectivity_paths = models
+
     def connectivity_models(self):
         models = {}
         for rst in self.__connectivity_models():
             models[rst['Model_ID']] = {"label": "", "version": ""}
         return models
+
+    def connectivity_paths(self):
+        return self.__connectivity_paths
 
     def build(self):
         return {

--- a/mapknowledge/nposparql.py
+++ b/mapknowledge/nposparql.py
@@ -292,7 +292,6 @@ class NpoSparql:
     def __init__(self):
         self.__sparql = SPARQLWrapper2(NPO_SPARQL_ENDPOINT)
         self.__load_apinatomy_connectivities() # load from file due to incompleteness in NPO
-        self.__load_connectivities() # get all connectivities promptly
 
     def query(self, sparql) -> list[dict]:
         self.__sparql.setQuery(sparql)
@@ -483,15 +482,11 @@ class NpoSparql:
                             filtered_connectivities += [edge]
                 self.__apinat_connectivities[neuron.strip()] = filtered_connectivities
 
-    def __load_connectivities(self):
+    def connectivity_models(self):
         models = {}
         for rst in self.__connectivity_models():
-            for neuron in self.__model_knowledge(rst['Model_ID']):
-                models[neuron['Neuron_ID']] = {"label": "", "version": ""}
-        self.__connectivities = models
-
-    def connectivity_models(self):
-        return self.__connectivities
+            models[rst['Model_ID']] = {"label": "", "version": ""}
+        return models
 
     def build(self):
         return {


### PR DESCRIPTION
In this PR:

- The `connectivity_models()` is reverted to the original functionality and 
- Adding `connectivity_paths()` to get all paths
- Modifying `self.__npo_entities` to get all paths from `connectivity_paths()`