### PR TITLE
#20 Returning alert as one of the neuron connectivity properties when present

### DIFF
--- a/mapknowledge/__init__.py
+++ b/mapknowledge/__init__.py
@@ -191,11 +191,12 @@ class KnowledgeStore(KnowledgeBase):
             self.__npo_db = NpoSparql()
             self.__npo_entities = set(self.__npo_db.connectivity_paths().keys())
             self.__npo_entities.update(self.__npo_db.connectivity_models().keys())
-            if log_build:
-                builds = self.__npo_db.build()
+            if log_build and len(builds:=self.__npo_db.build()) > 0:                
                 log.info(f"With NPO build {builds['released']}")
                 log.info(f"ApiNATOMY source: {builds['path']}")
                 log.info(f"ApiNATOMY built: {builds['date']}, SHA: {builds['sha']}")
+            else:
+                self.__npo_db = None    
         else:
             self.__npo_db = None
             log.info('Without NPO')

--- a/mapknowledge/nposparql.py
+++ b/mapknowledge/nposparql.py
@@ -401,6 +401,8 @@ class NpoSparql:
             knowledge['taxon'] = 'NCBITaxon:40674'      # Default to Mammalia
         if 'Sex' in metadata:
             knowledge['biologicalSex'] = metadata['Sex']
+        if 'Alert' in metadata:
+            knowledge['alert'] = metadata['Alert']
         connectivity = []
         if entity.startswith(NPO_NLP_NEURONS):
             for connection in self.__connectivity(entity):

--- a/mapknowledge/nposparql.py
+++ b/mapknowledge/nposparql.py
@@ -472,19 +472,23 @@ class NpoSparql:
                     r"\s+", " ", nested_structure).strip()
                 # adding coma
                 pattern = r"\[([^]]+)\]"
-
                 def add_comma(match):
                     elements = match.group(1).strip().split()
-                    return "[" + ", ".join(elements) + "]"
-
+                    return "[ " + " , ".join(elements) + " ]"
                 nested_structure = re.sub(pattern, add_comma, nested_structure)
-                # Quoting ILX and UBERON
-                pattern = r"(ILX:\d+|UBERON:\d+)"
+                # Quoting terms, e.g. UBERON, ILX
+                pattern = r"(\S+)"
                 nested_structure = re.sub(pattern, r'"\1"', nested_structure)
                 # Specifying tuple
-                nested_structure = nested_structure.replace(" )", ", )").replace(
-                    " ( ", ", ( "
-                )
+                nested_structure = nested_structure. \
+                    replace('"("', '('). \
+                    replace('")"', ')'). \
+                    replace('"["', '['). \
+                    replace('"]"', ']'). \
+                    replace('","', ','). \
+                    replace(" )", ", )"). \
+                    replace(" ( ", ", ( "). \
+                    replace('""', '"')
                 # convert to tuple
                 conn_structure = ast.literal_eval(nested_structure)
                 # parse connectivities


### PR DESCRIPTION
This PR:
- Include commits of #19 PR addessing #17 issue.
- Addressing #20 issue by returning `alert`
- Updating the NPO parsing of `apinat-partial-orders.ttl` as connectivity now also includes ilxtr terms. This update prevents mapknowledge from failing to run and accommodates terms not only UBERON and ILX.