### PR TITLE
Neurondm - filtering dendrite and axon, updating sckan_provenance info

### DIFF
--- a/mapknowledge/__init__.py
+++ b/mapknowledge/__init__.py
@@ -192,7 +192,7 @@ class KnowledgeStore(KnowledgeBase):
                 log.info(f"With {release_version} SCKAN{scicrunch_build} from {self.__scicrunch.sparc_api_endpoint}")
         else:
             self.__scicrunch = None
-            log.info('Without SCKAN')
+            log.info('Without Scicrunch')
         if npo:
             # self.__npo_db = NpoSparql()
             self.__npo_db = Npo(npo_release)

--- a/mapknowledge/__init__.py
+++ b/mapknowledge/__init__.py
@@ -183,11 +183,9 @@ class KnowledgeStore(KnowledgeBase):
                                          scicrunch_key=scicrunch_key)
             sckan_build = self.__scicrunch.build()
             if sckan_build is not None:
-                self.__sckan_provenance['sckan'] = {
-                    'scicrunch':{
-                        'url': scicrunch_api,
-                        'date': sckan_build['released']
-                    }
+                self.__sckan_provenance['scicrunch'] = {
+                    'url': scicrunch_api,
+                    'date': sckan_build['released']
                 }
             if log_build:
                 scicrunch_build = (f" built at {sckan_build['released']}" if sckan_build is not None else '')
@@ -203,8 +201,7 @@ class KnowledgeStore(KnowledgeBase):
             self.__npo_entities.update(self.__npo_db.connectivity_models().keys())
             npo_builds = self.__npo_db.build()
             if len(npo_builds):
-                if 'sckan' not in self.__sckan_provenance: self.__sckan_provenance['sckan'] = {}
-                self.__sckan_provenance['sckan']['npo'] = {
+                self.__sckan_provenance['npo'] = {
                         'date': npo_builds['released'],
                         'release': npo_builds['release'],
                         'path': npo_builds['path'],

--- a/mapknowledge/__init__.py
+++ b/mapknowledge/__init__.py
@@ -203,13 +203,12 @@ class KnowledgeStore(KnowledgeBase):
             self.__npo_entities.update(self.__npo_db.connectivity_models().keys())
             npo_builds = self.__npo_db.build()
             if len(npo_builds):
-                self.__sckan_provenance['sckan'] = {
-                    'npo':{
+                if 'sckan' not in self.__sckan_provenance: self.__sckan_provenance['sckan'] = {}
+                self.__sckan_provenance['sckan']['npo'] = {
                         'date': npo_builds['released'],
                         'release': npo_builds['release'],
                         'path': npo_builds['path'],
                         'sha': npo_builds['sha']
-                    }
                 }
                 if log_build:
                     log.info(f"With NPO built at {npo_builds['released']} from {npo_builds['path']}, SHA: {npo_builds['sha']}")

--- a/mapknowledge/__init__.py
+++ b/mapknowledge/__init__.py
@@ -184,7 +184,10 @@ class KnowledgeStore(KnowledgeBase):
             sckan_build = self.__scicrunch.build()
             if sckan_build is not None:
                 self.__sckan_provenance['sckan'] = {
-                    'date': sckan_build['released']
+                    'scicrunch':{
+                        'url': scicrunch_api,
+                        'date': sckan_build['released']
+                    }
                 }
             if log_build:
                 scicrunch_build = (f" built at {sckan_build['released']}" if sckan_build is not None else '')
@@ -200,18 +203,16 @@ class KnowledgeStore(KnowledgeBase):
             self.__npo_entities.update(self.__npo_db.connectivity_models().keys())
             npo_builds = self.__npo_db.build()
             if len(npo_builds):
-                self.__sckan_provenance['npo'] = {
-                    'date': npo_builds['released']
-                }
-                self.__sckan_provenance['apinatomy'] = {
-                    'date': npo_builds['date'],
-                    'path': npo_builds['path'],
-                    'sha': npo_builds['sha']
+                self.__sckan_provenance['sckan'] = {
+                    'npo':{
+                        'date': npo_builds['released'],
+                        'release': npo_builds['release'],
+                        'path': npo_builds['path'],
+                        'sha': npo_builds['sha']
+                    }
                 }
                 if log_build:
-                    log.info(f"With NPO build {npo_builds['released']}")
-                    log.info(f"ApiNATOMY source: {npo_builds['path']}")
-                    log.info(f"ApiNATOMY built: {npo_builds['date']}, SHA: {npo_builds['sha']}")
+                    log.info(f"With NPO built at {npo_builds['released']} from {npo_builds['path']}, SHA: {npo_builds['sha']}")
             else:
                 self.__npo_db = None    
         else:

--- a/mapknowledge/npo.py
+++ b/mapknowledge/npo.py
@@ -262,8 +262,8 @@ class Npo:
             response = request_json(f'{NPO_API}/git/refs/tags/{release["tag_name"]}')
             self.__npo_build = {
                 'sha': response['object']['sha'] if response is not None else release['tag_name'],
-                'date': release['created_at'],
                 'released': release['created_at'].split('T')[0],
+                'release': release["tag_name"],
                 'path': f'{NPO_GIT}/tree/{release["tag_name"]}'
             }
             return release['tag_name']

--- a/mapknowledge/npo.py
+++ b/mapknowledge/npo.py
@@ -239,14 +239,14 @@ def load_knowledge_from_ttl(npo_release):
         neuron['terms-dict'] = {NAMESPACES.curie(str(p.p)):str(p.pLabel) for p in n}
         neuron_terms = {**neuron_terms, **neuron['terms-dict']}
         neuron_knowledge[neuron['id']] = neuron
-    return neuron_knowledge, neuron_terms
+    return neuron_knowledge, neuron_terms, g
 
 #===============================================================================
 
 class Npo:
     def __init__(self, npo_release):
         self.__npo_release = self.__check_npo_release(npo_release)
-        self.__npo_knowledge, self.__npo_terms = load_knowledge_from_ttl(self.__npo_release)
+        self.__npo_knowledge, self.__npo_terms, self.__rdf_graph = load_knowledge_from_ttl(self.__npo_release)
 
     def __check_npo_release(self, npo_release):
         if (response:=request_json(f'{NPO_API}/releases')) is not None:
@@ -283,19 +283,22 @@ class Npo:
         knowledge = {
             'id': entity
         }
-        # check if entity is an ILX or UBERON term
+        # get label from npo_terms or from rdflib's graph
         if entity in self.__npo_terms:
             knowledge['label'] = self.__npo_terms[entity]
+        else:
+            if len(labels:=[o for o in self.__rdf_graph.objects(subject=NAMESPACES.uri(entity), predicate=rdfs.label)]) > 0:
+                knowledge['label'] = labels[0]
 
         # check if entity is a connectivity model
         if entity in self.connectivity_models():
-            knowledge['label'] = entity
+            if 'label' not in knowledge: knowledge['label'] = entity
             knowledge['paths'] = [{'id': v['id'], 'models': v['id']} for v in self.__npo_knowledge.values() if v['class'] == entity]
             knowledge['references'] = []
 
         # check if entity is a connecitvity path
         if (path_kn:=self.__npo_knowledge.get(entity)) is not None:
-            knowledge['label'] = path_kn['label']
+            if 'label' not in knowledge: knowledge['label'] = path_kn['label']
             knowledge['long-label'] = path_kn['label']
             knowledge['connectivity'] = path_kn['connectivity']
             if len(phenotype:=path_kn['phenotype']+path_kn['circuit_type']) > 0:
@@ -312,10 +315,12 @@ class Npo:
             for c in path_kn['connectivity']:
                 nodes[tuple([c[0][0]] + list(c[0][1]))] = c[0]
                 nodes[tuple([c[1][0]] + list(c[1][1]))] = c[1]
-            dendrites = [nodes[c] for d in path_kn['origin'] for c in nodes if d in c]
+            c_dendrites = {d:[c for c in nodes if d in c] for d in path_kn['origin']}
+            dendrites = [nodes[c] for cd_list in c_dendrites.values() for c in cd_list if len(c) == len(max(cd_list, key=len))]
             knowledge['dendrites'] = list(set(dendrites))
-            axons = [nodes[c] for a in path_kn['dest'] for c in nodes if a['loc'] in c]
-            knowledge['axons'] = axons
+            c_axons = {a['loc']:[c for c in nodes if a['loc'] in c] for a in path_kn['dest']}
+            axons = [nodes[c] for cd_list in c_axons.values() for c in cd_list if len(c) == len(max(cd_list, key=len))]
+            knowledge['axons'] = list(set(axons))
             if len(references:=path_kn['provenance']) > 0:
                 knowledge['references'] = references
 


### PR DESCRIPTION
- filtering dendrite and axon, for example:
`'dendrites': [('UBERON:0016580', ('UBERON:0006447',)),`
`               ('UBERON:0006447', ()),`
`               ('UBERON:0016580', ('ILX:0738432',)),`
`               ('ILX:0738432', ())]`
become:
`'dendrites': [('UBERON:0016580', ('UBERON:0006447',)),`
`               ('UBERON:0016580', ('ILX:0738432',))]`

- retrieving term's label from rdflib graph in neurondm
- updating sckan_provenance information related to the the source of information, i.e. using Scicrunch only, using NPO only, using Scicrunch and NPO