### PR TITLE
Fix foreign key constraint to use sckan_node_id

### DIFF
--- a/sql/map-knowledge.schema.sql
+++ b/sql/map-knowledge.schema.sql
@@ -307,6 +307,6 @@ ALTER TABLE ONLY public.path_node_mappings
 ALTER TABLE ONLY public.path_node_mappings
     ADD CONSTRAINT sckan_path_constraint FOREIGN KEY (sckan_id, path_id) REFERENCES public.feature_terms(source_id, term_id);
 ALTER TABLE ONLY public.path_node_mappings
-    ADD CONSTRAINT sckan_node_constraint FOREIGN KEY (sckan_id, path_id, node_id) REFERENCES public.path_nodes(source_id, path_id, node_id);
+    ADD CONSTRAINT sckan_node_constraint FOREIGN KEY (sckan_id, path_id, sckan_node_id) REFERENCES public.path_nodes(source_id, path_id, node_id);
 
 --------------------------------------------------------------


### PR DESCRIPTION
This PR addresses an issue discovered after the merge of #64

An incorrect foreign key constraint definition caused a loading error. This update corrects the constraint to use sckan_node_id instead of node_id.

This PR resolves the issue introduced in #63.